### PR TITLE
Allow configuration of the interpreter to use

### DIFF
--- a/src/debugdeploy.ts
+++ b/src/debugdeploy.ts
@@ -76,10 +76,10 @@ class DeployCodeDeployer implements ICodeDeployer {
 
     const prefs = this.preferences.getPreferences(workspace);
 
-    let deploy = `"${file}" deploy --team=${await prefs.getTeamNumber()}`;
+    const deploy = [file, 'deploy', `--team=${await prefs.getTeamNumber()}`];
 
     if (prefs.getSkipTests()) {
-      deploy += ' --skip-tests';
+      deploy.push('--skip-tests');
     }
 
     await pythonRun(deploy, workspace.uri.fsPath, workspace, 'Python Deploy');

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -4,12 +4,14 @@ import * as vscode from 'vscode';
 
 const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('python');
 
-export function executeCommandAsync(command: string, rootDir: string, ow?: vscode.OutputChannel): Promise<number> {
+export function executeCommandAsync(command: string, args: string[], rootDir: string, ow?: vscode.OutputChannel): Promise<number> {
   return new Promise((resolve, _) => {
-    const exec = child_process.exec;
-    const child = exec(command, {
+    const spawn = child_process.spawn;
+    const child = spawn(command, args, {
       cwd: rootDir,
-    }, (err) => {
+    });
+
+    child.on('exit', (err) => {
       if (err) {
         resolve(1);
       } else {
@@ -31,10 +33,10 @@ export function executeCommandAsync(command: string, rootDir: string, ow?: vscod
   });
 }
 
-export async function pythonRun(args: string, rootDir: string, _workspace: vscode.WorkspaceFolder, _name: string): Promise<number> {
-  const command = 'python ' + args;
+export async function pythonRun(args: string[], rootDir: string, _workspace: vscode.WorkspaceFolder, _name: string): Promise<number> {
+  const interpreter = 'python';
 
   outputChannel.clear();
   outputChannel.show();
-  return executeCommandAsync(command, rootDir, outputChannel);
+  return executeCommandAsync(interpreter, args, rootDir, outputChannel);
 }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -34,7 +34,8 @@ export function executeCommandAsync(command: string, args: string[], rootDir: st
 }
 
 export async function pythonRun(args: string[], rootDir: string, _workspace: vscode.WorkspaceFolder, _name: string): Promise<number> {
-  const interpreter = 'python';
+  const configuration = vscode.workspace.getConfiguration();
+  const interpreter: string = configuration.get('python.pythonPath') || 'python';
 
   outputChannel.clear();
   outputChannel.show();


### PR DESCRIPTION
The VS Code Python extension allows the user to pick which installed Python interpreter to use.  Since on most systems the default Python interpreter (i.e. `python`) is Python 2, it is imperative that we respect the user's choice here.

This also refactors the executor module to take an array of arguments rather than an entire command line as a single string to avoid starting a redundant shell and wasting CPU cycles splitting the command line.  This also fixes a subtle bug where this would break on paths containing double-quotes (which is possible on Unix filesystems).